### PR TITLE
Add TACAN and ICLS codes to carriers

### DIFF
--- a/Levant-theater/Turkey/Airbase/CVN-59.dct
+++ b/Levant-theater/Turkey/Airbase/CVN-59.dct
@@ -6,4 +6,6 @@ subordinates = {}
 desc = "CV-59 Forrestal"
 recoverytype = "land"
 takeofftype = "runway"
+tacan = "59X QJ"
+icls = 12
 cost = 20

--- a/Levant-theater/Turkey/Airbase/CVN-73.dct
+++ b/Levant-theater/Turkey/Airbase/CVN-73.dct
@@ -6,4 +6,6 @@ subordinates = {"VF111", "VF143", "VFA97"}
 desc = "CVN-73 George Washington"
 recoverytype = "land"
 takeofftype = "runway"
+tacan = "73X GW"
+icls = 11
 cost = 20

--- a/Levant-theater/Turkey/Airbase/LHA-4.dct
+++ b/Levant-theater/Turkey/Airbase/LHA-4.dct
@@ -6,4 +6,6 @@ subordinates = {"VMA331"}
 desc = "LHA-4 Nassau"
 recoverytype = "land"
 takeofftype = "runway"
+tacan = "31X LH"
+icls = 4
 cost = 20


### PR DESCRIPTION
This sets up TACAN and ICLS codes in the carrier templates so that DCT can keep them refreshed and up to date in case DCS stops them from transmitting.

Settings:
| Carrier | TACAN Frequency | TACAN Callsign (Morse Code) | ICLS |
---|---|---|---
| CVN-73 George Washington | 73X | GW | 11 |
| CV-59 Forrestal | 59X | QJ | 12 |
| LHA-4 Nassau | 31X | LH | 4 |

Some notes:
* The current mission briefing image shows all free boats on 74X, it needs to be updated before this is released
* The current TACAN callsigns for the boats in the .miz are the full names of the carrier, which is extremely hard to understand in morse code
* After this is deployed, the TACAN settings can be removed from the miz
* This doesn't work with airfields or FARPs, only carrier units
