### PR TITLE
Remove EWR HARM code from mission briefings

### DIFF
--- a/Levant-theater/Aleppo/EWR/Reg1EWR-1.dct
+++ b/Levant-theater/Aleppo/EWR/Reg1EWR-1.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR.
 
 Threats: SHORAD around the EWR, and several strategic SAM sites around Aleppo and Kuweires.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Coast/EWR/Reg2EWR-1.dct
+++ b/Levant-theater/Coast/EWR/Reg2EWR-1.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR near Latakia.
 
 Threats: Heavy SAM defenses, enemy CAP from the nearby airbase, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Coast/EWR/Reg2EWR-2.dct
+++ b/Levant-theater/Coast/EWR/Reg2EWR-2.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR south of Baniyas.
 
 Threats: Heavy SAM defenses, enemy CAP from the nearby airbase, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Damascus/Ewr/Reg6ewr1.dct
+++ b/Levant-theater/Damascus/Ewr/Reg6ewr1.dct
@@ -9,6 +9,4 @@ Primary objective: Eliminate the EWR.
 
 Threats: Damascus SAM network, Interceptors from Al-Dumayr and Sayqal and AAA from the site itself.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Hama/EWR/Reg3EWR-1.dct
+++ b/Levant-theater/Hama/EWR/Reg3EWR-1.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR near Hama.
 
 Threats: Heavy SAM defenses, enemy CAP and interceptors, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Hama/EWR/Reg3EWR-2.dct
+++ b/Levant-theater/Hama/EWR/Reg3EWR-2.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR in the Air Defense Academy.
 
 Threats: Heavy SAM defenses, enemy CAP and interceptors, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Palmyra/EWR/Reg4EWR-1.dct
+++ b/Levant-theater/Palmyra/EWR/Reg4EWR-1.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR in Tiyas.
 
 Threats: Heavy SAM defenses, enemy CAP from several directions, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Palmyra/EWR/Reg4EWR-2.dct
+++ b/Levant-theater/Palmyra/EWR/Reg4EWR-2.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR in Palmyra.
 
 Threats: SA-2s, enemy CAP, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]

--- a/Levant-theater/Palmyra/EWR/Reg4EWR-3.dct
+++ b/Levant-theater/Palmyra/EWR/Reg4EWR-3.dct
@@ -8,6 +8,4 @@ Primary objective: Eliminate the EWR in Tabqa.
 
 Threats: SA-2s, enemy CAP, and SHORAD within the EWR site.
 
-HARM code: 102
-
 Recommended pilots: 2]]


### PR DESCRIPTION
Remove the HARM code for EWRs from mission briefings, since ED patched out the HARM's ability to track EWRs a while back.