### PR TITLE
Add AAA to Sam Emplacements to give them some minor self defensive capabilities 

### DIFF
--- a/Levant-theater/Aleppo/Sa2/Reg1Sa2-1.stm
+++ b/Levant-theater/Aleppo/Sa2/Reg1Sa2-1.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 48,
+                                        ["y"] = 133458.6255218,
+                                        ["x"] = 113273.83690244,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.9618974020271,
+                                    }, -- end of [11]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 47,
+                                        ["y"] = 133340.7236531,
+                                        ["x"] = 113269.04757922,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 2.2165681500328,
+                                    }, -- end of [12]
                                 }, -- end of ["units"]
                                 ["y"] = 133401.14214643,
                                 ["x"] = 113240.27303365,

--- a/Levant-theater/Aleppo/sa3/reg1sa3-1.stm
+++ b/Levant-theater/Aleppo/sa3/reg1sa3-1.stm
@@ -801,6 +801,28 @@ staticTemplate =
                                         ["heading"] = 0.05235987755983,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [8]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "Average",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 36,
+                                        ["y"] = 110154.97796432,
+                                        ["x"] = 130774.30634762,
+                                        ["name"] = "Sa3 1-10",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.05235987755983,
+                                    }, -- end of [9]
+                                    [10] = 
+                                    {
+                                        ["skill"] = "Average",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 35,
+                                        ["y"] = 109962.44770887,
+                                        ["x"] = 130827.84862328,
+                                        ["name"] = "Sa3 1-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.05235987755983,
+                                    }, -- end of [10]
                                 }, -- end of ["units"]
                                 ["y"] = 110088.13792423,
                                 ["x"] = 130821.74120189,

--- a/Levant-theater/Aleppo/sa3/reg1sa3-2.stm
+++ b/Levant-theater/Aleppo/sa3/reg1sa3-2.stm
@@ -801,6 +801,28 @@ staticTemplate =
                                         ["heading"] = 0.05235987755983,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [8]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "Average",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 59,
+                                        ["y"] = 127654.53545871,
+                                        ["x"] = 123635.23570828,
+                                        ["name"] = "Sa3 1-10",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.47123889803847,
+                                    }, -- end of [8]
+                                    [10] = 
+                                    {
+                                        ["skill"] = "Average",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 58,
+                                        ["y"] = 127706.88525297,
+                                        ["x"] = 123771.80038896,
+                                        ["name"] = "Sa3 1-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.6128315516283,
+                                    }, -- end of [9]
                                 }, -- end of ["units"]
                                 ["y"] = 127720.78533016,
                                 ["x"] = 123695.2990366,

--- a/Levant-theater/Aleppo/sa3/reg1sa3-3.stm
+++ b/Levant-theater/Aleppo/sa3/reg1sa3-3.stm
@@ -582,6 +582,28 @@ staticTemplate =
                                         ["heading"] = 6.2641478001644,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [7]
+                                    [8] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 68,
+                                        ["y"] = 153819.57603447,
+                                        ["x"] = 125675.51521418,
+                                        ["name"] = "SA-3-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 4.9741883681838,
+                                    }, -- end of [6]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 67,
+                                        ["y"] = 153731.6822654,
+                                        ["x"] = 125810.91115801,
+                                        ["name"] = "SA-3-8",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.1415926535898,
+                                    }, -- end of [7]
                                 }, -- end of ["units"]
                                 ["y"] = 153749.39673919,
                                 ["x"] = 125768.83670473,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-1.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-1.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 80,
+                                        ["y"] = 3185.202519419,
+                                        ["x"] = 43327.21766458,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 2.9670597283904,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 81,
+                                        ["y"] = 3437.2220810254,
+                                        ["x"] = 43352.819738164,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.069813170079773,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = 3311.0138628819,
                                 ["x"] = 43321.339042537,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-2.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-2.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 93,
+                                        ["y"] = -8551.7804211638,
+                                        ["x"] = 66436.007983254,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.069813170079773,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 94,
+                                        ["y"] = -8337.4904721865,
+                                        ["x"] = 66417.661241047,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.1764992386297,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = -8445.6026378981,
                                 ["x"] = 66431.11971376,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-3.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-3.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 106,
+                                        ["y"] = -6909.7587788405,
+                                        ["x"] = 61154.024469981,
+                                        ["name"] = "Checkpoint-15-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.87266462599716,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 107,
+                                        ["y"] = -6657.1544871214,
+                                        ["x"] = 61200.467411508,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 4.0491638646268,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = -6792.4020363617,
                                 ["x"] = 61181.958186232,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-4.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-4.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 158,
+                                        ["y"] = 5937.3716423097,
+                                        ["x"] = 23614.997679515,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.1241393610699,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 159,
+                                        ["y"] = 5946.3559689148,
+                                        ["x"] = 23338.729636411,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 6.2482787221397,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = 5943.6219677357,
                                 ["x"] = 23489.999512777,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-5.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-5.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 171,
+                                        ["y"] = 2678.2517574501,
+                                        ["x"] = -7617.9262059226,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.73303828583762,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 172,
+                                        ["y"] = 2785.2405974293,
+                                        ["x"] = -7490.7371372989,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.9793506945471,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = 2726.5911898609,
                                 ["x"] = -7543.3807620826,

--- a/Levant-theater/Coast/SA2/Reg2Sa2-6.stm
+++ b/Levant-theater/Coast/SA2/Reg2Sa2-6.stm
@@ -652,6 +652,28 @@ staticTemplate =
                                         ["heading"] = 5.3407075111026,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [11]
+                                    [12] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 184,
+                                        ["y"] = 6548.8107691275,
+                                        ["x"] = -40565.666834742,
+                                        ["name"] = "Checkpoint-16-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0.73303828583762,
+                                    }, -- end of [12]
+                                    [13] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 186,
+                                        ["y"] = 6697.1466274702,
+                                        ["x"] = -40395.663940911,
+                                        ["name"] = "Checkpoint-17-1",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.8397243543875,
+                                    }, -- end of [13]
                                 }, -- end of ["units"]
                                 ["y"] = 6618.5626797794,
                                 ["x"] = -40465.22563745,

--- a/Levant-theater/Coast/sa3/reg2sa3-1.stm
+++ b/Levant-theater/Coast/sa3/reg2sa3-1.stm
@@ -592,6 +592,28 @@ staticTemplate =
                                         ["heading"] = 6.2641478001644,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [7]
+                                    [8] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 194,
+                                        ["y"] = -9232.3245007684,
+                                        ["x"] = 58402.974897242,
+                                        ["name"] = "Sa-3-8",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.1415926535898,
+                                    }, -- end of [8]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 195,
+                                        ["y"] = -9230.1144506337,
+                                        ["x"] = 58283.632189969,
+                                        ["name"] = "Sa-3-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0,
+                                    }, -- end of [9]
                                 }, -- end of ["units"]
                                 ["y"] = -9233.330556488,
                                 ["x"] = 58371.883115397,

--- a/Levant-theater/Coast/sa3/reg2sa3-2.stm
+++ b/Levant-theater/Coast/sa3/reg2sa3-2.stm
@@ -592,6 +592,28 @@ staticTemplate =
                                         ["heading"] = 6.2641478001644,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [7]
+                                    [8] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 203,
+                                        ["y"] = 4257.536627866,
+                                        ["x"] = 48965.329299136,
+                                        ["name"] = "Sa-3-8",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.1241393610699,
+                                    }, -- end of [8]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 204,
+                                        ["y"] = 4260.3677603751,
+                                        ["x"] = 48860.908773143,
+                                        ["name"] = "Sa-3-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 0,
+                                    }, -- end of [9]
                                 }, -- end of ["units"]
                                 ["y"] = 4257.1072263719,
                                 ["x"] = 48941.134977291,

--- a/Levant-theater/Coast/sa3/reg2sa3-3.stm
+++ b/Levant-theater/Coast/sa3/reg2sa3-3.stm
@@ -592,6 +592,28 @@ staticTemplate =
                                         ["heading"] = 6.2641478001644,
                                         ["playerCanDrive"] = false,
                                     }, -- end of [7]
+                                    [8] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 212,
+                                        ["y"] = 5544.6711893846,
+                                        ["x"] = 22071.207755242,
+                                        ["name"] = "Sa-3-8",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 6.2308254296198,
+                                    }, -- end of [8]
+                                    [9] = 
+                                    {
+                                        ["skill"] = "High",
+                                        ["type"] = "Ural-375 ZU-23",
+                                        ["unitId"] = 213,
+                                        ["y"] = 5542.4066195288,
+                                        ["x"] = 22198.023667166,
+                                        ["name"] = "Sa-3-9",
+                                        ["playerCanDrive"] = false,
+                                        ["heading"] = 3.08923277603,
+                                    }, -- end of [9]
                                 }, -- end of ["units"]
                                 ["y"] = 5540.6545150556,
                                 ["x"] = 22157.987877825,


### PR DESCRIPTION
SAM emplacements are pretty trivial to destroy, particularly in the early game, by just getting close. 

This PR is to add some AAA to otherwise undefended SAM emplacements.

Initially I'm adding a pair of ZU-23-2 Urals to the SA-2/3 emplacements on the Aleppo and Coast regions. We may want to discuss upping the AAA threat for sites further into the campaign, but this is a good start for now. 