### PR TITLE
Remove misleading instruction to return troops after mission

### DIFF
--- a/Levant-theater/Hatay/Recon/reg1AR5.dct
+++ b/Levant-theater/Hatay/Recon/reg1AR5.dct
@@ -11,7 +11,7 @@ A squad of the Polish Airborne Forces is ready to be transported and deployed to
 
 Primary objective: Search and destroy the enemy mortars.
 
-Secondary objective: Transport the airborne troops to the AO, and bring them back to Iskenderun after completing the mission.
+Secondary objective: Transport the airborne troops to the AO.
 
 Threats: Small arms fire and MANPADS.
 


### PR DESCRIPTION
Fixes bug reported by "Unclesam": https://discord.com/channels/894586277121388584/1195712154851094630

The Polish troops despawn on mission completion, so the instruction to return them after the mission is nonsensical.