### PR TITLE
Improve description of Hama factory mission

### DIFF
--- a/Levant-theater/Hama/STRIKES/Reg3Factory-8.dct
+++ b/Levant-theater/Hama/STRIKES/Reg3Factory-8.dct
@@ -10,8 +10,8 @@ buildings = {
         ["id"]   = 75081120,
     },
 }
-desc = [[%LOCATIONMETHOD% a weapons factory south of Hama, on the city limits, south of the stadium. You can identify it by its smoke stacks, its on the last block on the city.
-Caution, this target is in a populated area, be selective with weapons placement to prevent civilian casualties.
+desc = [[%LOCATIONMETHOD% a weapons factory on the outskirts of Hama. The factory is in an industrial park on the south edge of the city, directly east across the highway from a farm containing greenhouses. The primary facility is the multi-story building in the center of the complex with two smokestacks.
+The target is near suburbs and agricultural fields. Be selective with weapons placement to avoid civilian casualties.
 
 Primary objective: Destroy the factory.
 


### PR DESCRIPTION
This particular mission has been reported by players as confusing because the stadium referenced in the description is 2.6 miles away, across half the city. Changed to reference which side of the city the objective is located on and provide references to a highway and farm within 3000ft, as well as suburbs and farms nearby.

[Fixes issue reported by "Hexe" on Discord](https://discord.com/channels/894586277121388584/1209569439792631840/1209569878445527150)