### PR TITLE
Set GBU-8 cost to 15

### DIFF
--- a/Levant-theater/settings/restrictedweapons.cfg
+++ b/Levant-theater/settings/restrictedweapons.cfg
@@ -287,4 +287,8 @@ restrictedweapons = {
 		["cost"] = 5000,
 		["category"] = "ag",
 	},
+	["HB_F4E_GBU_8_HOBOS"] = {
+		["cost"] = 15,
+		["category"] = "ag",
+	},
 }


### PR DESCRIPTION
Currently the F4E is capable of carrying 2 HOBOS and 4 Mavericks due to HOBOS having no cost. This change will still allow 4 HOBOS but not an excessive 6 PGM loadout.